### PR TITLE
Usability improvements

### DIFF
--- a/src/App.config
+++ b/src/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
 </configuration>

--- a/src/EliteScreenshotConverter.csproj
+++ b/src/EliteScreenshotConverter.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>NZgeek.EliteScreenshotConverter</RootNamespace>
     <AssemblyName>EliteScreenshotConverter</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
@@ -40,9 +40,6 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NZgeek.ElitePlayerJournal, Version=0.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\NZgeek.ElitePlayerJournal.0.1.0\lib\net452\NZgeek.ElitePlayerJournal.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
@@ -55,6 +52,12 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\ElitePlayerJournal\src\ElitePlayerJournal.net452.csproj">
+      <Project>{195b246a-62a6-4399-944a-4ad55e722994}</Project>
+      <Name>ElitePlayerJournal.net452</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/EliteScreenshotConverterWithJournal.sln
+++ b/src/EliteScreenshotConverterWithJournal.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.6
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EliteScreenshotConverter", "EliteScreenshotConverter.csproj", "{F7E9DCE7-D9BD-421E-A4AF-4F038CF2C1E4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ElitePlayerJournal.net452", "..\..\ElitePlayerJournal\src\ElitePlayerJournal.net452.csproj", "{195B246A-62A6-4399-944A-4AD55E722994}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F7E9DCE7-D9BD-421E-A4AF-4F038CF2C1E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F7E9DCE7-D9BD-421E-A4AF-4F038CF2C1E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F7E9DCE7-D9BD-421E-A4AF-4F038CF2C1E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F7E9DCE7-D9BD-421E-A4AF-4F038CF2C1E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{195B246A-62A6-4399-944A-4AD55E722994}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{195B246A-62A6-4399-944A-4AD55E722994}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{195B246A-62A6-4399-944A-4AD55E722994}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{195B246A-62A6-4399-944A-4AD55E722994}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/EliteScreenshotConverterWithJournalCode.sln
+++ b/src/EliteScreenshotConverterWithJournalCode.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.7
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EliteScreenshotConverter", "EliteScreenshotConverter.csproj", "{F7E9DCE7-D9BD-421E-A4AF-4F038CF2C1E4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ElitePlayerJournal.net452", "..\..\ElitePlayerJournal\src\ElitePlayerJournal.net452.csproj", "{195B246A-62A6-4399-944A-4AD55E722994}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F7E9DCE7-D9BD-421E-A4AF-4F038CF2C1E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F7E9DCE7-D9BD-421E-A4AF-4F038CF2C1E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F7E9DCE7-D9BD-421E-A4AF-4F038CF2C1E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F7E9DCE7-D9BD-421E-A4AF-4F038CF2C1E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{195B246A-62A6-4399-944A-4AD55E722994}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{195B246A-62A6-4399-944A-4AD55E722994}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{195B246A-62A6-4399-944A-4AD55E722994}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{195B246A-62A6-4399-944A-4AD55E722994}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8D1ADA27-0CD2-4F52-9F0B-91FD18299BC2}
+	EndGlobalSection
+EndGlobal

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -24,7 +24,7 @@ namespace NZgeek.EliteScreenshotConverter
             var screenshotEvents = Enumerable.Reverse(journal.FindEvents(startDate, endDate, EventType.Screenshot));
             foreach (Screenshot screenshotEvent in screenshotEvents)
             {
-                Console.WriteLine("[{0:yyyy/MM/dd HH:mm:ss}] {1}  @  {2}{3}",
+                Console.WriteLine("[{0:yyyy/MM/dd HH:mm:ss}] {1} @ {2}{3}",
                     screenshotEvent.Timestamp,
                     screenshotEvent.FilePath,
                     screenshotEvent.SystemName,

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -21,16 +21,16 @@ namespace NZgeek.EliteScreenshotConverter
             var startDate = ParseStartDateArgument(args);
             var endDate = ParseEndDateArgument(args);
 
-            var screenshots = Enumerable.Reverse(journal.FindEvents(startDate, endDate, EventType.Screenshot));
-            foreach (Screenshot screenshot in screenshots)
+            var screenshotEvents = Enumerable.Reverse(journal.FindEvents(startDate, endDate, EventType.Screenshot));
+            foreach (Screenshot screenshotEvent in screenshotEvents)
             {
                 Console.WriteLine("[{0:yyyy/MM/dd HH:mm:ss}] {1}  @  {2}{3}",
-                    screenshot.Timestamp,
-                    screenshot.FilePath,
-                    screenshot.SystemName,
-                    !string.IsNullOrEmpty(screenshot.Body) ? $" ({screenshot.Body})" : null);
+                    screenshotEvent.Timestamp,
+                    screenshotEvent.FilePath,
+                    screenshotEvent.SystemName,
+                    !string.IsNullOrEmpty(screenshotEvent.Body) ? $" ({screenshotEvent.Body})" : null);
 
-                ConvertScreenshot(screenshot);
+                ConvertScreenshot(screenshotEvent);
             }
 
             Console.WriteLine("Press enter to exit");
@@ -61,27 +61,27 @@ namespace NZgeek.EliteScreenshotConverter
             return DateTime.MinValue;
         }
 
-        static void ConvertScreenshot(Screenshot screenshot)
+        static void ConvertScreenshot(Screenshot screenshotEvent)
         {
-            if (!File.Exists(screenshot.FilePath))
+            if (!File.Exists(screenshotEvent.FilePath))
                 return;
 
-            var convertedFolder = Path.Combine(screenshot.Journal.ScreenShotFolder, "Converted");
+            var convertedFolder = Path.Combine(screenshotEvent.Journal.ScreenShotFolder, "Converted");
             Directory.CreateDirectory(convertedFolder);
 
-            var convertedFileName = BuildFileName(screenshot);
+            var convertedFileName = BuildFileName(screenshotEvent);
             var convertedFilePath = Path.Combine(convertedFolder, convertedFileName.ToString());
 
-            using (var sourceImage = new Bitmap(screenshot.FilePath))
+            using (var sourceImage = new Bitmap(screenshotEvent.FilePath))
             {
                 sourceImage.Save(convertedFilePath, ImageFormat.Jpeg);
             }
 
-            File.Delete(screenshot.FilePath);
+            File.Delete(screenshotEvent.FilePath);
 
-            if (screenshot.Timestamp != DateTime.MinValue)
+            if (screenshotEvent.Timestamp != DateTime.MinValue)
             {
-                File.SetCreationTime(convertedFilePath, screenshot.Timestamp);
+                File.SetCreationTime(convertedFilePath, screenshotEvent.Timestamp);
             }
         }
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -32,6 +32,9 @@ namespace NZgeek.EliteScreenshotConverter
 
                 ConvertScreenshot(screenshot);
             }
+
+            Console.WriteLine("Press enter to exit");
+            Console.ReadLine();
         }
 
         private static DateTime ParseEndDateArgument(string[] args)


### PR DESCRIPTION
Use creation date of BMP when creating JPG file.
Ensure body name in filename doesnt repeat system name.
Ensure filename doesnt contain double spaces.
Update to 461
Pause after execution has finished